### PR TITLE
Treat time off request type as a string

### DIFF
--- a/model_time_off.go
+++ b/model_time_off.go
@@ -32,7 +32,7 @@ type TimeOff struct {
 	// The number of time off units requested.
 	Amount NullableFloat32 `json:"amount,omitempty"`
 	// The type of time off request.
-	RequestType NullableRequestTypeEnum `json:"request_type,omitempty"`
+	RequestType NullableString `json:"request_type,omitempty"`
 	// The day and time of the start of the time requested off.
 	StartTime NullableTime `json:"start_time,omitempty"`
 	// The day and time of the end of the time requested off.
@@ -385,25 +385,6 @@ func (o *TimeOff) UnsetAmount() {
 	o.Amount.Unset()
 }
 
-// GetRequestType returns the RequestType field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *TimeOff) GetRequestType() RequestTypeEnum {
-	if o == nil || o.RequestType.Get() == nil {
-		var ret RequestTypeEnum
-		return ret
-	}
-	return *o.RequestType.Get()
-}
-
-// GetRequestTypeOk returns a tuple with the RequestType field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-// NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *TimeOff) GetRequestTypeOk() (*RequestTypeEnum, bool) {
-	if o == nil  {
-		return nil, false
-	}
-	return o.RequestType.Get(), o.RequestType.IsSet()
-}
-
 // HasRequestType returns a boolean if a field has been set.
 func (o *TimeOff) HasRequestType() bool {
 	if o != nil && o.RequestType.IsSet() {
@@ -411,15 +392,6 @@ func (o *TimeOff) HasRequestType() bool {
 	}
 
 	return false
-}
-
-// SetRequestType gets a reference to the given NullableRequestTypeEnum and assigns it to the RequestType field.
-func (o *TimeOff) SetRequestType(v RequestTypeEnum) {
-	o.RequestType.Set(&v)
-}
-// SetRequestTypeNil sets the value for RequestType to be an explicit nil
-func (o *TimeOff) SetRequestTypeNil() {
-	o.RequestType.Set(nil)
 }
 
 // UnsetRequestType ensures that no value is present for RequestType, not even an explicit nil


### PR DESCRIPTION
## Description of the change

This changes the time off type to treat request type as a string, which allows us to always get the exact name of the specified time off request type instead of `MERGE_NONSTANDARD_VALUE`, which is what was being returned before when this type was an enum.

Note that the file I changed is _supposed_ to be generated by the OpenAPI Generator, but when I tried using that instead, it made a lot of changes to other generated files which looked like they would break a lot of things. So doing the hacky thing and changing this manually for now.

Hopefully Merge will do something about this, and then we can get rid of this fork, but until then this is necessary.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
